### PR TITLE
Added compiler check for boost::python std::shared_ptr handling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,29 @@ include_directories(
   ${PYTHON_INCLUDE_DIRS}
 )
 
+# Check whether the CXX compiler and boost::python support get_pointer for
+# std::shared_ptr<T> references.
+include(CheckCXXSourceCompiles)
+set(CMAKE_REQUIRED_INCLUDES
+  ${Boost_INCLUDE_DIRS}
+  ${PYTHON_INCLUDE_DIRS}
+)
+set(CMAKE_REQUIRED_LIBRARIES
+  ${Boost_LIBRARIES}
+  ${PYTHON_LIBRARIES}
+)
+check_cxx_source_compiles(
+  "
+  #include <memory>
+  #include <boost/python.hpp>
+  int main() { std::shared_ptr<int> ptr; int *p = boost::get_pointer(ptr); }
+  "
+  HAS_STD_SHARED_GET_POINTER
+)
+if(HAS_STD_SHARED_GET_POINTER)
+  add_definitions(-DHAS_STD_SHARED_GET_POINTER)
+endif(HAS_STD_SHARED_GET_POINTER)
+
 add_library(${PROJECT_NAME} SHARED
   src/python.cpp
   src/python_BodyNode.cpp

--- a/src/pointers.h
+++ b/src/pointers.h
@@ -103,11 +103,13 @@ inline JointPtr_wrapper_base JointPtr_wrapper_create(
 
 namespace boost {
 
+#ifndef HAS_STD_SHARED_GET_POINTER
 template <class T>
 T *get_pointer(std::shared_ptr<T> const &ptr) 
 {
     return ptr.get();
 }
+#endif // ifndef HAS_STD_SHARED_GET_POINTER
 
 inline dart::dynamics::BodyNode *get_pointer(
     dart::dynamics::BodyNodePtr const &p)


### PR DESCRIPTION
This adds a compiler check to address the issue @PyryM was having with `get_pointer<std::shared_ptr>()` being already defined in `gcc` but not in `clang`.
