### PR TITLE
Feature: Working packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,9 +83,11 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 )
 
 # Install the python extension using setuputils.
-install(${PROJECT_NAME}
+install(CODE
+  "
   execute_process(COMMAND python setup.py install -f
                           --prefix=${CMAKE_INSTALL_PREFIX}
                   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   )
+  "
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 2.8)
 project(dartpy)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "RELWITHDEBINFO")
+endif()
 
 add_definitions(-DPROJECT_NAME=${PROJECT_NAME})
 
@@ -54,4 +57,12 @@ target_link_libraries(${PROJECT_NAME}
 set_target_properties(${PROJECT_NAME} PROPERTIES
   PREFIX ""
   SUFFIX ".so"
+)
+
+# Install the python extension using setuputils.
+install(${PROJECT_NAME}
+  execute_process(COMMAND python setup.py install -f
+                          --prefix=${CMAKE_INSTALL_PREFIX}
+                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  )
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,11 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 # Install the python extension using setuputils.
 install(CODE
   "
-  execute_process(COMMAND python setup.py install -f
+  execute_process(COMMAND python setup.py
+                          build_ext
+                          --build-temp=${PROJECT_BINARY_DIR}
+                          install
+                          --force
                           --prefix=${CMAKE_INSTALL_PREFIX}
                   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[bdist_wheel]
+
+# This flag says that the code is written to work on both Python 2 and Python
+# 3. If at all possible, it is good practice to do this so that we do not need
+# to generate wheels for each Python version that you support.
+
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+import os
+from codecs import open  # To use a consistent encoding
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+
+# Get the current directory path.
+here = os.path.abspath(os.path.dirname(__file__))
+
+# Extract the description from the top-level README.
+with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+description = 'dartpy provides python bindings for DART.'
+
+
+# Build extension library using CMake.
+class cmake_build_ext(build_ext):
+    """ Wrapper class that builds the extension using CMake. """
+    def build_extension(self, ext):
+        build_ext.build_extension(self, ext)
+
+# Set up the python package wrapping this extension.
+setup(
+    name='dartpy',
+    version='0.0.1',
+    description=description,
+    long_description=long_description,
+    ext_modules=[Extension('dartpy')],
+    url='https://github.com/personalrobotics/dartpy',
+    author='Michael Koval',
+    author_email='mkoval@cs.cmu.edu',
+    license='BSD',
+    keywords='dartsim robotics',
+    classifiers=[
+        'Development Status :: 1 - Planning',
+        'License :: BSD',
+        'Intended Audience :: Developers',
+    ],
+    install_requires=[
+        'boost_python',
+    ],
+    cmdclass={'build_ext': cmake_build_ext},
+)

--- a/setup.py
+++ b/setup.py
@@ -30,12 +30,10 @@ def chdir(dirname=None):
 class cmake_build_ext(build_ext):
     """ Wrapper class that builds the extension using CMake. """
     def run(self):
-        # The directory containing this setup.py
-        source_path = os.dirname(os.abspath(__file__))
-
-        # Build using CMake from the specified build directory.
+        """ Build using CMake from the specified build directory. """
+        self.mkpath(self.build_temp)
         with chdir(self.build_temp):
-            self.spawn(['cmake', source_path])
+            self.spawn(['cmake', here])
             self.spawn(['make'])
 
 # Set up the python package wrapping this extension.
@@ -54,9 +52,6 @@ setup(
         'Development Status :: 1 - Planning',
         'License :: BSD',
         'Intended Audience :: Developers',
-    ],
-    install_requires=[
-        'boost_python',
     ],
     cmdclass={'build_ext': cmake_build_ext},
 )

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ description = 'dartpy provides python bindings for DART.'
 class cmake_build_ext(build_ext):
     """ Wrapper class that builds the extension using CMake. """
     def build_extension(self, ext):
+        # TODO: add CMake build commands here.
         build_ext.build_extension(self, ext)
 
 # Set up the python package wrapping this extension.


### PR DESCRIPTION
This PR adds fixes to the `CMakeLists.txt` and adds a `setup.py` that allows dartpy to be built and installed through both `CMake` and `pip`.

This should be merged after https://github.com/personalrobotics/dartpy/pull/1.