### PR TITLE
Add option to specify target Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ install:
 script:
   - mkdir build
   - cd build
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then cmake ..; fi
-  #- if [ "$TRAVIS_OS_NAME" = "osx"   ]; then cmake ..; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then cmake .. -DDARTPY_PYTHON_VERSION=$TRAVIS_PYTHON_VERSION; fi
   - if [ "$TRAVIS_BRANCH" != "*-binding" ]; then make binding; fi
   - make -j4
   - sudo make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ if(${PYTHON_VERSION_MAJOR} EQUAL 3)
   endif()
 else()
   find_package(Boost REQUIRED COMPONENTS python thread)
+  set(DARTPY_Boost_PYTHON_LIBRARIES ${Boost_PYTHON_LIBRARIES})
 endif()
 
 find_package(DART 6.3.0 REQUIRED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,14 @@
 cmake_minimum_required(VERSION 2.8)
 project(dartpy)
 
+if(NOT DARTPY_PYTHON_VERSION)
+  set(DARTPY_PYTHON_VERSION 3.4 CACHE STRING "Choose the target Python version (e.g., 3.4, 2.7)" FORCE)
+endif()
+
 # TODO: This should be set by DART.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-deprecated -Wno-deprecated-declarations")
 
-find_package(PythonInterp REQUIRED)
+find_package(PythonInterp ${DARTPY_PYTHON_VERSION} REQUIRED)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
   "from distutils.sysconfig import get_python_lib;\
   print(get_python_lib(plat_specific=True, prefix=''))"
@@ -22,7 +26,7 @@ find_package(DART 6.3.0 REQUIRED
     gui-osg
   CONFIG
 )
-find_package(PythonLibs REQUIRED)
+find_package(PythonLibs ${DARTPY_PYTHON_VERSION} REQUIRED)
 find_package(chimera QUIET)
 
 include_directories(SYSTEM

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,10 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
 
 if(${PYTHON_VERSION_MAJOR} EQUAL 3)
   find_package(Boost COMPONENTS python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} thread)
+  set(DARTPY_Boost_PYTHON_LIBRARIES ${Boost_PYTHON-PY${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_LIBRARIES})
   if (NOT Boost_FOUND)
     find_package(Boost REQUIRED COMPONENTS python3 thread)
+    set(DARTPY_Boost_PYTHON_LIBRARIES ${Boost_PYTHON3_LIBRARIES})
   endif()
 else()
   find_package(Boost REQUIRED COMPONENTS python thread)
@@ -87,7 +89,7 @@ if(chimera_FOUND)
     DEBUG EXCLUDE_FROM_ALL
   )
   target_link_libraries("${PROJECT_NAME}_CHIMERA"
-    ${Boost_PYTHON_LIBRARIES}
+    ${DARTPY_Boost_PYTHON_LIBRARIES}
     ${DART_LIBRARIES}
     ${PYTHON_LIBRARIES}
   )
@@ -116,7 +118,7 @@ if(EXISTS "${SOURCES_TXT}")
     src/template_registry.cpp
   )
   target_link_libraries("${PROJECT_NAME}"
-    ${Boost_PYTHON_LIBRARIES}
+    ${DARTPY_Boost_PYTHON_LIBRARIES}
     ${DART_LIBRARIES}
     ${PYTHON_LIBRARIES}
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,15 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-find_package(Boost REQUIRED COMPONENTS python thread)
+if(${PYTHON_VERSION_MAJOR} EQUAL 3)
+  find_package(Boost COMPONENTS python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} thread)
+  if (NOT Boost_FOUND)
+    find_package(Boost REQUIRED COMPONENTS python3 thread)
+  endif()
+else()
+  find_package(Boost REQUIRED COMPONENTS python thread)
+endif()
+
 find_package(DART 6.3.0 REQUIRED
   COMPONENTS
     collision-bullet


### PR DESCRIPTION
Previously, `dartpy` always was built for Python 2 because CMake finds `PythonInterp` and `PythonLibs` packages for Python 2 by default if the version is not specified. This PR enables us to specify the target Python version when running `cmake`.

The default Python version is now 3.4 (default version on Trusty), but I'm open to change it to other versions.