### PR TITLE
Change to travis-ci.org badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dartpy [![Build Status](https://travis-ci.com/personalrobotics/dartpy.svg?token=1MmAniN9fkMcwpRUTdFq&branch=master)](https://travis-ci.com/personalrobotics/dartpy) #
+# dartpy [![Build Status](https://travis-ci.org/personalrobotics/dartpy.svg?branch=master)](https://travis-ci.org/personalrobotics/dartpy) #
 
 > :warning: **Warning:** `dartpy` is under heavy development. See the open
 > issues on [`dartpy`](https://github.com/personalrobotics/dartpy/issues) and


### PR DESCRIPTION
This PR changes the Travis CI badge to travis.org as `dartpy` became a public repository.