### PR TITLE
Include dart header after boost inclusion check

### DIFF
--- a/include/dartpy/pointers.h
+++ b/include/dartpy/pointers.h
@@ -9,7 +9,11 @@
 #endif
 
 #include "get_signature.h"
+
 #include <dart/dynamics/dynamics.hpp>
+// TODO(JS): This includes Boost headers, which conflicts with 
+// the above ifdef statement. Confirm whether this doesn't cause
+// any issues.
 
 namespace boost {
 

--- a/include/dartpy/pointers.h
+++ b/include/dartpy/pointers.h
@@ -1,7 +1,6 @@
 #ifndef DART_PYTHON_POINTERS_H_
 #define DART_PYTHON_POINTERS_H_
 #include <memory>
-#include <dart/dynamics/dynamics.hpp>
 #include <dartpy/config.h>
 #include "types.h"
 
@@ -10,6 +9,7 @@
 #endif
 
 #include "get_signature.h"
+#include <dart/dynamics/dynamics.hpp>
 
 namespace boost {
 


### PR DESCRIPTION
DART 6.4 includes some boost headers in dynamics headers. This makes `pointers.h` is not compilable. This PR fixes it by including `dart/dynamics/dynamics.hpp` after the boost inclusion check. @mkoval @psigen Could you take a look if this is a correct way to fix the issue?