### PR TITLE
Add manually coded bindings for Skel file parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dartpy 0 (prerelease)
 
+### 0.0.3 (20XX-XX-XX)
+
+* Added skel file parsing functions: [#64](https://github.com/personalrobotics/dartpy/pull/64)
+
 ### 0.0.2 (2018-05-23)
 
 * Updated C++ DART version to 6.5.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ if(EXISTS "${SOURCES_TXT}")
     ${SOURCES_GENERATED}
     src/BodyNode.cpp
     src/Skeleton.cpp
+    src/skel_parser.cpp
     src/template_registry.cpp
   )
   target_link_libraries("${PROJECT_NAME}"

--- a/chimera/chimera.yml
+++ b/chimera/chimera.yml
@@ -119,6 +119,9 @@ template:
         dart::dynamics::DegreeOfFreedom*, dart::dynamics::DegreeOfFreedomPtr>();
       dart::python::util::collection_from_python<
         std::vector<dart::dynamics::DegreeOfFreedom*> >();
+    postcontent: |
+      void skel_parser();
+      skel_parser();
     footer: |
       // main footer
 

--- a/chimera/chimera.yml
+++ b/chimera/chimera.yml
@@ -120,6 +120,7 @@ template:
       dart::python::util::collection_from_python<
         std::vector<dart::dynamics::DegreeOfFreedom*> >();
     postcontent: |
+      ::boost::python::scope().attr("utils").attr("skel") = ::boost::python::object(::boost::python::handle<>(::boost::python::borrowed(::PyImport_AddModule("dartpy.utils.skel"))));
       void skel_parser();
       skel_parser();
     footer: |

--- a/chimera/chimera.yml
+++ b/chimera/chimera.yml
@@ -119,6 +119,10 @@ template:
         dart::dynamics::DegreeOfFreedom*, dart::dynamics::DegreeOfFreedomPtr>();
       dart::python::util::collection_from_python<
         std::vector<dart::dynamics::DegreeOfFreedom*> >();
+
+      dart::python::util::vector_to_python<dart::simulation::WorldPtr>();
+      dart::python::util::collection_from_python<
+        std::vector<dart::simulation::WorldPtr> >();
     postcontent: |
       ::boost::python::scope().attr("utils").attr("skel") = ::boost::python::object(::boost::python::handle<>(::boost::python::borrowed(::PyImport_AddModule("dartpy.utils.skel"))));
       void skel_parser();
@@ -1382,7 +1386,7 @@ classes:
 
 
 
-# Shapes
+  # Shapes
   'dart::dynamics::Shape':
     held_type: 'std::shared_ptr<dart::dynamics::Shape>'
   'dart::dynamics::BoxShape':
@@ -1417,6 +1421,10 @@ classes:
     held_type: 'dart::dynamics::GroupPtr'
   'dart::dynamics::Linkage':
     held_type: 'dart::dynamics::LinkagePtr'
+
+  # World
+  'dart::simulation::World':
+    held_type: 'dart::simulation::WorldPtr'
 
   # Cloneable<T> names
   'dart::common::Cloneable<dart::common::Aspect::Properties>':

--- a/chimera/templates/module.mstch.cpp
+++ b/chimera/templates/module.mstch.cpp
@@ -32,6 +32,6 @@ BOOST_PYTHON_MODULE({{module.name}})
   }
 
 {{/module.bindings}}
-}
 {{{postcontent}}}
+}
 {{{footer}}}

--- a/src/skel_parser.cpp
+++ b/src/skel_parser.cpp
@@ -20,13 +20,13 @@ void skel_parser()
 ::boost::python::object parent_object(::boost::python::scope().attr("utils").attr("skel"));
 ::boost::python::scope parent_scope(parent_object);
 
-::boost::python::def("readWorld", [](const dart::common::Uri & uri) -> dart::simulation::WorldPtr { return dart::utils::skel::readWorld(uri); }, (::boost::python::arg("uri")));
-::boost::python::def("readWorld", [](const dart::common::Uri & uri, const dart::common::ResourceRetrieverPtr & retriever) -> dart::simulation::WorldPtr { return dart::utils::skel::readWorld(uri, retriever); }, (::boost::python::arg("uri"), ::boost::python::arg("retriever")));
-::boost::python::def("readWorldXML", [](const std::string & xmlString) -> dart::simulation::WorldPtr { return dart::utils::skel::readWorldXML(xmlString); }, (::boost::python::arg("xmlString")));
-::boost::python::def("readWorldXML", [](const std::string & xmlString, const dart::common::Uri & baseUri) -> dart::simulation::WorldPtr { return dart::utils::skel::readWorldXML(xmlString, baseUri); }, (::boost::python::arg("xmlString"), ::boost::python::arg("baseUri")));
-::boost::python::def("readWorldXML", [](const std::string & xmlString, const dart::common::Uri & baseUri, const dart::common::ResourceRetrieverPtr & retriever) -> dart::simulation::WorldPtr { return dart::utils::skel::readWorldXML(xmlString, baseUri, retriever); }, (::boost::python::arg("xmlString"), ::boost::python::arg("baseUri"), ::boost::python::arg("retriever")));
-::boost::python::def("readSkeleton", [](const dart::common::Uri & uri) -> dart::dynamics::SkeletonPtr { return dart::utils::skel::readSkeleton(uri); }, (::boost::python::arg("uri")));
-::boost::python::def("readSkeleton", [](const dart::common::Uri & uri, const dart::common::ResourceRetrieverPtr & retriever) -> dart::dynamics::SkeletonPtr { return dart::utils::skel::readSkeleton(uri, retriever); }, (::boost::python::arg("uri"), ::boost::python::arg("retriever")));
+::boost::python::def("readWorld", [](const dart::common::Uri & uri) -> dart::simulation::WorldPtr { return dart::utils::SkelParser::readWorld(uri); }, (::boost::python::arg("uri")));
+::boost::python::def("readWorld", [](const dart::common::Uri & uri, const dart::common::ResourceRetrieverPtr & retriever) -> dart::simulation::WorldPtr { return dart::utils::SkelParser::readWorld(uri, retriever); }, (::boost::python::arg("uri"), ::boost::python::arg("retriever")));
+::boost::python::def("readWorldXML", [](const std::string & xmlString) -> dart::simulation::WorldPtr { return dart::utils::SkelParser::readWorldXML(xmlString); }, (::boost::python::arg("xmlString")));
+::boost::python::def("readWorldXML", [](const std::string & xmlString, const dart::common::Uri & baseUri) -> dart::simulation::WorldPtr { return dart::utils::SkelParser::readWorldXML(xmlString, baseUri); }, (::boost::python::arg("xmlString"), ::boost::python::arg("baseUri")));
+::boost::python::def("readWorldXML", [](const std::string & xmlString, const dart::common::Uri & baseUri, const dart::common::ResourceRetrieverPtr & retriever) -> dart::simulation::WorldPtr { return dart::utils::SkelParser::readWorldXML(xmlString, baseUri, retriever); }, (::boost::python::arg("xmlString"), ::boost::python::arg("baseUri"), ::boost::python::arg("retriever")));
+::boost::python::def("readSkeleton", [](const dart::common::Uri & uri) -> dart::dynamics::SkeletonPtr { return dart::utils::SkelParser::readSkeleton(uri); }, (::boost::python::arg("uri")));
+::boost::python::def("readSkeleton", [](const dart::common::Uri & uri, const dart::common::ResourceRetrieverPtr & retriever) -> dart::dynamics::SkeletonPtr { return dart::utils::SkelParser::readSkeleton(uri, retriever); }, (::boost::python::arg("uri"), ::boost::python::arg("retriever")));
 
 }
 

--- a/src/skel_parser.cpp
+++ b/src/skel_parser.cpp
@@ -1,0 +1,33 @@
+#include <dartpy/pointers.h>
+#include <dartpy/template_registry.h>
+#include <dart/dart.hpp>
+#include <dart/collision/bullet/bullet.hpp>
+#include <dart/optimizer/optimizer.hpp>
+#include <dart/optimizer/nlopt/nlopt.hpp>
+#include <dart/planning/planning.hpp>
+#include <dart/utils/utils.hpp>
+#include <dart/utils/urdf/urdf.hpp>
+#include <dart/gui/gui.hpp>
+
+/* precontent */
+#include <boost/python.hpp>
+#include <cmath>
+
+/* postinclude */
+
+void skel_parser()
+{
+::boost::python::object parent_object(::boost::python::scope().attr("utils").attr("skel"));
+::boost::python::scope parent_scope(parent_object);
+
+::boost::python::def("readWorld", [](const dart::common::Uri & uri) -> dart::simulation::WorldPtr { return dart::utils::skel::readWorld(uri); }, (::boost::python::arg("uri")));
+::boost::python::def("readWorld", [](const dart::common::Uri & uri, const dart::common::ResourceRetrieverPtr & retriever) -> dart::simulation::WorldPtr { return dart::utils::skel::readWorld(uri, retriever); }, (::boost::python::arg("uri"), ::boost::python::arg("retriever")));
+::boost::python::def("readWorldXML", [](const std::string & xmlString) -> dart::simulation::WorldPtr { return dart::utils::skel::readWorldXML(xmlString); }, (::boost::python::arg("xmlString")));
+::boost::python::def("readWorldXML", [](const std::string & xmlString, const dart::common::Uri & baseUri) -> dart::simulation::WorldPtr { return dart::utils::skel::readWorldXML(xmlString, baseUri); }, (::boost::python::arg("xmlString"), ::boost::python::arg("baseUri")));
+::boost::python::def("readWorldXML", [](const std::string & xmlString, const dart::common::Uri & baseUri, const dart::common::ResourceRetrieverPtr & retriever) -> dart::simulation::WorldPtr { return dart::utils::skel::readWorldXML(xmlString, baseUri, retriever); }, (::boost::python::arg("xmlString"), ::boost::python::arg("baseUri"), ::boost::python::arg("retriever")));
+::boost::python::def("readSkeleton", [](const dart::common::Uri & uri) -> dart::dynamics::SkeletonPtr { return dart::utils::skel::readSkeleton(uri); }, (::boost::python::arg("uri")));
+::boost::python::def("readSkeleton", [](const dart::common::Uri & uri, const dart::common::ResourceRetrieverPtr & retriever) -> dart::dynamics::SkeletonPtr { return dart::utils::skel::readSkeleton(uri, retriever); }, (::boost::python::arg("uri"), ::boost::python::arg("retriever")));
+
+}
+
+/* footer */


### PR DESCRIPTION
Due to https://github.com/personalrobotics/chimera/issues/168 (and https://github.com/personalrobotics/dartpy/issues/37), bindings for `dart::utils::SkelParser` are not automatically generated by chimera.

This PR adds the missing bindings, which are manually written using `Boost.Python`.

**Usage:**
```python
import dartpy as dart
world1 = dart.utils.skel.readWorld('uri_or_filepath')
world2 = dart.utils.skel.readWorldXML(xml_string)
skel = dart.utils.skel.readSkeleton('uri_or_filepath')
```