### PR TITLE
Allow copy construction of Skeleton::Configuration

### DIFF
--- a/chimera/chimera.yml
+++ b/chimera/chimera.yml
@@ -891,6 +891,9 @@ classes:
   'dart::dynamics::DegreeOfFreedom':
     held_type: dart::dynamics::DegreeOfFreedomPtr
 
+  'dart::dynamics::Skeleton::Configuration':
+    is_copyable: true
+
   # Nodes
   'dart::dynamics::JacobianNode':
     held_type: dart::dynamics::TemplateNodePtr<dart::dynamics::JacobianNode, dart::dynamics::BodyNode>


### PR DESCRIPTION
This PR fixes that `skel.getCinfiguration()` wasn't able to call.

```python3
import dartpy as dart
skel = dart.dynamics.Skeleton.create()
config = skel.getConfiguration() # okay now!
```