### PR TITLE
Add ::boost::python to RVP directives in template

### DIFF
--- a/chimera/templates/cxx_record.mstch.cpp
+++ b/chimera/templates/cxx_record.mstch.cpp
@@ -62,7 +62,7 @@ void {{class.mangled_name}}()
 }}{{#overloads}}{{!
     }}.def("{{name}}", []({{#is_const}}const {{/is_const}}{{{class.type}}} *self{{#params}}, {{{type}}} {{name}}{{/params}}) -> {{{return_type}}} { {{!
     }}return self->{{{call}}}({{#params}}{{name}}{{^last}}, {{/last}}{{/params}}); }{{!
-    }}{{#return_value_policy}}, ::boost::python::return_value_policy<{{{.}}} >(){{/return_value_policy}}{{!
+    }}{{#return_value_policy}}, ::boost::python::return_value_policy<::boost::python::{{{.}}} >(){{/return_value_policy}}{{!
     }}{{#comment?}}, {{mangled_name}}_docstring{{/comment?}}{{!
     }}{{#params?}}, ({{#params}}::boost::python::arg("{{name}}"){{^last}}, {{/last}}{{/params}}){{/params?}})
 {{/overloads}}{{!
@@ -75,7 +75,7 @@ void {{class.mangled_name}}()
 }}{{#overloads}}{{!
     }}.def("{{name}}", []({{#params}}{{{type}}} {{name}}{{^last}}, {{/last}}{{/params}}) -> {{{return_type}}} { {{!
     }}return {{{qualified_call}}}({{#params}}{{name}}{{^last}}, {{/last}}{{/params}}); }{{!
-    }}{{#return_value_policy}}, ::boost::python::return_value_policy<{{{.}}} >(){{/return_value_policy}}{{!
+    }}{{#return_value_policy}}, ::boost::python::return_value_policy<::boost::python::{{{.}}} >(){{/return_value_policy}}{{!
     }}{{#params?}}, ({{#params}}::boost::python::arg("{{name}}"){{^last}}, {{/last}}{{/params}}){{/params?}})
 {{/overloads}}{{!
 }}{{/is_static}}{{!

--- a/chimera/templates/function.mstch.cpp
+++ b/chimera/templates/function.mstch.cpp
@@ -17,7 +17,7 @@ void {{function.mangled_name}}()
 {{#function.overloads}}{{!
     }}::boost::python::def("{{name}}", []({{#params}}{{{type}}} {{name}}{{^last}}, {{/last}}{{/params}}) -> {{{return_type}}} { {{!
     }}return {{{qualified_call}}}({{#params}}{{name}}{{^last}}, {{/last}}{{/params}}); }{{!
-    }}{{#return_value_policy}}, ::boost::python::return_value_policy<{{{.}}} >(){{/return_value_policy}}{{!
+    }}{{#return_value_policy}}, ::boost::python::return_value_policy<::boost::python::{{{.}}} >(){{/return_value_policy}}{{!
     }}{{#params?}}, ({{#params}}::boost::python::arg("{{name}}"){{^last}}, {{/last}}{{/params}}){{/params?}});
 {{/function.overloads}}
 


### PR DESCRIPTION
This PR updates the `boost_python` template. This change was missing in #71.