### PR TITLE
Update chimera configuration for ConstraintSolver::getCollisionDetector()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ endif()
 find_package(DART 6.3.0 REQUIRED
   COMPONENTS
     collision-bullet
+    # collision-ode
     optimizer-nlopt
     planning
     utils-urdf

--- a/chimera/chimera.cpp
+++ b/chimera/chimera.cpp
@@ -1,5 +1,6 @@
 #include <dart/dart.hpp>
 #include <dart/collision/bullet/bullet.hpp>
+#include <dart/collision/ode/ode.hpp>
 #include <dart/optimizer/optimizer.hpp>
 #include <dart/optimizer/nlopt/nlopt.hpp>
 //#include <dart/optimizer/nlopt/ipopt.hpp> TODO: make this optional

--- a/chimera/chimera.cpp
+++ b/chimera/chimera.cpp
@@ -1,6 +1,6 @@
 #include <dart/dart.hpp>
 #include <dart/collision/bullet/bullet.hpp>
-#include <dart/collision/ode/ode.hpp>
+// #include <dart/collision/ode/ode.hpp>
 #include <dart/optimizer/optimizer.hpp>
 #include <dart/optimizer/nlopt/nlopt.hpp>
 //#include <dart/optimizer/nlopt/ipopt.hpp> TODO: make this optional

--- a/chimera/chimera.yml
+++ b/chimera/chimera.yml
@@ -22,6 +22,7 @@ template:
       #include <dartpy/template_registry.h>
       #include <dart/dart.hpp>
       #include <dart/collision/bullet/bullet.hpp>
+      #include <dart/collision/ode/ode.hpp>
       #include <dart/optimizer/optimizer.hpp>
       #include <dart/optimizer/nlopt/nlopt.hpp>
       #include <dart/planning/planning.hpp>
@@ -45,6 +46,7 @@ template:
       #include <dartpy/util.h>
       #include <dart/dart.hpp>
       #include <dart/collision/bullet/bullet.hpp>
+      #include <dart/collision/ode/ode.hpp>
       #include <dart/optimizer/optimizer.hpp>
       #include <dart/optimizer/nlopt/nlopt.hpp>
       #include <dart/planning/planning.hpp>
@@ -606,6 +608,8 @@ types:
 
   'dart::dynamics::ConstSkeletonPtr': null
   'dart::dynamics::ConstShapePtr': null
+
+  'std::shared_ptr<const dart::collision::CollisionDetector>': null
 
 # Selected function and class declarations that need custom parameters.
 classes:
@@ -1382,16 +1386,15 @@ classes:
   # 'dart::dynamics::SkeletonSpecializedFor<dart::dynamics::ShapeNode, dart::dynamics::EndEffector, dart::dynamics::Marker>': null
   'dart::collision::detail::UnorderedPairs<dart::dynamics::BodyNode>': null
 
-
-
-
-
-
-
-
-
-
-
+  # Collision
+  'dart::collision::BulletCollisionDetector':
+    held_type: 'std::shared_ptr<dart::collision::BulletCollisionDetector>'
+  'dart::collision::DARTCollisionDetector':
+    held_type: 'std::shared_ptr<dart::collision::DARTCollisionDetector>'
+  'dart::collision::FCLCollisionDetector':
+    held_type: 'std::shared_ptr<dart::collision::FCLCollisionDetector>'
+  'dart::collision::OdeCollisionDetector':
+    held_type: 'std::shared_ptr<dart::collision::OdeCollisionDetector>'
 
   # Shapes
   'dart::dynamics::Shape':

--- a/chimera/chimera.yml
+++ b/chimera/chimera.yml
@@ -22,7 +22,6 @@ template:
       #include <dartpy/template_registry.h>
       #include <dart/dart.hpp>
       #include <dart/collision/bullet/bullet.hpp>
-      #include <dart/collision/ode/ode.hpp>
       #include <dart/optimizer/optimizer.hpp>
       #include <dart/optimizer/nlopt/nlopt.hpp>
       #include <dart/planning/planning.hpp>
@@ -46,7 +45,6 @@ template:
       #include <dartpy/util.h>
       #include <dart/dart.hpp>
       #include <dart/collision/bullet/bullet.hpp>
-      #include <dart/collision/ode/ode.hpp>
       #include <dart/optimizer/optimizer.hpp>
       #include <dart/optimizer/nlopt/nlopt.hpp>
       #include <dart/planning/planning.hpp>
@@ -1393,8 +1391,8 @@ classes:
     held_type: 'std::shared_ptr<dart::collision::DARTCollisionDetector>'
   'dart::collision::FCLCollisionDetector':
     held_type: 'std::shared_ptr<dart::collision::FCLCollisionDetector>'
-  'dart::collision::OdeCollisionDetector':
-    held_type: 'std::shared_ptr<dart::collision::OdeCollisionDetector>'
+  # 'dart::collision::OdeCollisionDetector':
+  #   held_type: 'std::shared_ptr<dart::collision::OdeCollisionDetector>'
 
   # Shapes
   'dart::dynamics::Shape':

--- a/chimera/chimera.yml
+++ b/chimera/chimera.yml
@@ -1387,6 +1387,8 @@ classes:
   'dart::collision::detail::UnorderedPairs<dart::dynamics::BodyNode>': null
 
   # Collision
+  'dart::collision::CollisionDetector':
+    held_type: 'std::shared_ptr<dart::collision::CollisionDetector>'
   'dart::collision::BulletCollisionDetector':
     held_type: 'std::shared_ptr<dart::collision::BulletCollisionDetector>'
   'dart::collision::DARTCollisionDetector':

--- a/chimera/chimera.yml
+++ b/chimera/chimera.yml
@@ -22,6 +22,7 @@ template:
       #include <dartpy/template_registry.h>
       #include <dart/dart.hpp>
       #include <dart/collision/bullet/bullet.hpp>
+      // #include <dart/collision/ode/ode.hpp>
       #include <dart/optimizer/optimizer.hpp>
       #include <dart/optimizer/nlopt/nlopt.hpp>
       #include <dart/planning/planning.hpp>
@@ -45,6 +46,7 @@ template:
       #include <dartpy/util.h>
       #include <dart/dart.hpp>
       #include <dart/collision/bullet/bullet.hpp>
+      // #include <dart/collision/ode/ode.hpp>
       #include <dart/optimizer/optimizer.hpp>
       #include <dart/optimizer/nlopt/nlopt.hpp>
       #include <dart/planning/planning.hpp>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ else()
 endif()
 
 set(DARTPY_TEST_FILES
+  comprehensive/test_collision_detector.py
   regression/test_get_shape.py
   unit/test_dart_loader.py
 )

--- a/tests/comprehensive/test_collision_detector.py
+++ b/tests/comprehensive/test_collision_detector.py
@@ -1,0 +1,25 @@
+import platform
+
+import pytest
+from dartpy.utils import DartLoader
+from dartpy.simulation import World
+
+from tests.util import get_asset_path
+
+
+def test_parse_joint_properties():
+    loader = DartLoader()
+    robot = loader.parseSkeleton(get_asset_path('urdf/joint_properties.urdf'))
+    assert robot is not None
+
+    world = World.create()
+    world.addSkeleton(robot)
+
+    cs = world.getConstraintSolver()
+    assert cs is not None
+
+    cd = cs.getCollisionDetector()
+    assert cd is not None
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
This should enable following code:
```python
import dartpy as dart
world = dart.simulation.World.create()
cs = world.getConstraintSolver()
cd = cs.getCollisionDetector()
```
once these builds are done:
* https://code.launchpad.net/~personalrobotics/+archive/ubuntu/ppa/+build/14969781
* https://code.launchpad.net/~personalrobotics/+archive/ubuntu/ppa/+build/14969782
* https://code.launchpad.net/~personalrobotics/+archive/ubuntu/ppa/+build/14969783